### PR TITLE
Removed WP_HTTP_BLOCK_EXTERNAL

### DIFF
--- a/app/templates/wp-config.php.tmpl
+++ b/app/templates/wp-config.php.tmpl
@@ -74,12 +74,6 @@ define('WP_HOME',    'http://' . $_SERVER['SERVER_NAME'] . '<%= userInput.port %
 define('WP_CONTENT_DIR', __dir__ . '/<%= userInput.contentDir %>');
 define('WP_CONTENT_URL', 'http://' . $_SERVER['SERVER_NAME'] . '<%= userInput.port %>/<%= userInput.contentDir %>');
 
-/**
- * Disable external requests
- *
- * This is so that users dont see update requests since things are managed through git
- */
-define('WP_HTTP_BLOCK_EXTERNAL', true);
 <% } %>
 /**
  * For developers: WordPress debugging mode.


### PR DESCRIPTION
As per #32.

Didn't include an option to include this again as I felt it's a fairly niche requirement. :)
