### PR TITLE
Fixes issue #51 - Arguments to path.join must be strings (Windows 7)

### DIFF
--- a/util/config.js
+++ b/util/config.js
@@ -12,7 +12,7 @@ var Config = module.exports = function(locals, globals) {
 	this.filename = '.yeopress';
 
 	// Load files
-	this.global = this.load(path.join(process.env.HOME, this.filename)) || {};
+	this.global = this.load(path.join(process.env.HOME || process.env.USERPROFILE, this.filename)) || {};
 	this.local = this.load() || {};
 
 	// Set initial data


### PR DESCRIPTION
``` process.env.HOME```

Wasn't set on Windows 7 64bit, as was displaying as undefined.

Fixes issue #51 - Arguments to path.join must be strings (Windows 7)
```
