### PR TITLE
Backward support for PHP 5.2, should solve issue #42

### DIFF
--- a/app/templates/wp-config.php.tmpl
+++ b/app/templates/wp-config.php.tmpl
@@ -85,7 +85,7 @@ if (!defined('WP_HOME')) {
 	define('WP_HOME',    'http://' . $_SERVER['SERVER_NAME'] . '<%= (conf.get('port')) ? ':' + conf.get('port') : '' %>');
 }
 if (!defined('WP_CONTENT_DIR')) {
-	define('WP_CONTENT_DIR', __dir__ . '/<%= conf.get('contentDir') %>');
+	define('WP_CONTENT_DIR', dirname(__FILE__) . '/<%= conf.get('contentDir') %>');
 }
 if (!defined('WP_CONTENT_URL')) {
 	define('WP_CONTENT_URL', 'http://' . $_SERVER['SERVER_NAME'] . '<%= (conf.get('port')) ? ':' + conf.get('port') : '' %>/<%= conf.get('contentDir') %>');


### PR DESCRIPTION
Small change that solves issue #42 on my MAMP installation. It seems that `__dir__` magic variable works only with PHP >= 5.3 so I slightly changed the code to support PHP 5.2
