### PR TITLE
Added "refresh remote" option to advanced setup.

### DIFF
--- a/app/prompts.js
+++ b/app/prompts.js
@@ -184,6 +184,15 @@ module.exports = function(advanced, defaults) {
 				return !!res.installTheme && res.themeType == 'git';
 			}
 		}, {
+			message: 'Refresh remote (busts potentially cached theme)',
+			name: 'refreshRemote',
+			type: 'confirm',
+			default: defaults.refreshRemote || true,
+			validate: requiredValidate,
+			when: function(res) {
+				return !!res.installTheme && res.themeType == 'git';
+			}
+		}, {
 			message: 'Remote tarball url',
 			name: 'themeTarballUrl',
 			default: defaults.themeTarballUrl || 'https://github.com/wesleytodd/YeoPress/archive/template.tar.gz',

--- a/util/wordpress.js
+++ b/util/wordpress.js
@@ -240,7 +240,7 @@ function installTheme(generator, config, done) {
 		generator.remote(config.themeUser, config.themeRepo, config.themeBranch, function(err, remote) {
 			remote.directory('.', path.join(config.contentDir, 'themes', config.themeDir));
 			done();
-		});
+		}, config.refreshRemote);
 	} else if (config.themeType == 'tar') {
 		generator.tarball(config.themeTarballUrl, path.join(config.contentDir, 'themes', config.themeDir), done);
 	}


### PR DESCRIPTION
Added "refresh remote" option to advanced setup. Since Yeoman caches remotes, this allows the user to fetch a fresh copy of a custom theme, instead of a potentially cached and out-of-date version.