### PR TITLE
fixes issue with a null conflict while installing wordpress

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -223,7 +223,7 @@ Generator.prototype.wordWhatUp = function() {
 
 		this.logger.log('Installing WordPress ' + this.conf.get('wpVer'));
 		this.remote('wordpress', 'wordpress', this.conf.get('wpVer'), function(err, remote) {
-			remote.bulkDirectory('.', me.conf.get('wpDir'));
+			remote.directory('.', me.conf.get('wpDir'));
 			me.logger.log('WordPress installed');
 			done();
 		});


### PR DESCRIPTION
I believe this should fix issue #132.

For some reason bulkDirectory() wanted to run a conflict check with null and always found a conflict. Doing some research the Yeoman API doc says to not use bulkDirectory() unless there's no other solution. directory() does the same conflict resolution but doesn't generate a null check, so I think that takes care of the automatic conflict issue.