### PR TITLE
Update version of grunt-contrib-sass in package.json to 0.9.2 to fix...

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "BSD",
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-contrib-sass": "~0.2.2",
+    "grunt-contrib-sass": "~0.9.2",
     "grunt-contrib-jshint": "~0.1.1", 
     "grunt-bower-requirejs": "~0.4.1",
     "grunt-contrib-requirejs": "~0.4.0",


### PR DESCRIPTION
conflict with newer SASS versions and the error 'Error generating source map: couldn't determine public URL for the source stylesheet.'