### PR TITLE
The task "bower" is deprecated

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -127,9 +127,9 @@ module.exports = function(grunt) {
 		},
 
 		// Bower task sets up require config
-		bower : {
-			all : {
-				rjsConfig : 'js/global.js'
+		bowerRequirejs: {
+			target: {
+				rjsConfig: 'js/global.js'
 			}
 		},
 


### PR DESCRIPTION
The task "bower" is deprecated for grunt-bower-requirejs. Use "bowerRequirejs" instead