### PR TITLE
Fixes #169

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -98,7 +98,7 @@ Generator.prototype.plugItInPlugItIn = function() {
 	})();
 
 	function installPlugin(plugin, cb) {
-		me.tarball('http://downloads.wordpress.org/plugin/' + plugin + '.zip', path.join(me.conf.get('contentDir') || 'wp-content', 'plugins', plugin), cb);
+		me.tarball('http://downloads.wordpress.org/plugin/' + plugin + '.zip', path.join(me.conf.get('contentDir') || 'wp-content', 'plugins'), cb);
 	}
 
 };


### PR DESCRIPTION
The zip files from the wordpress plugin repository already contain a folder with the name of the plugin slug, so `plugin` in path.join is redundant.