### PR TITLE
Remove Bitdeli badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,3 @@ Custom themes can be installed from GitHub or a Tarball.  Once installed, they a
 
 More information on themes [here](https://github.com/wesleytodd/YeoPress/wiki/Themes) & [here](http://wesleytodd.com/2013/5/yeopress-themes.html)
 
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/wesleytodd/yeopress/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-


### PR DESCRIPTION
Love the project! Since GitHub started caching images in readmes, Bitdeli has stopped functioning. There's more information about this here: 

http://blog.bitdeli.com/post/77717727361/on-githubs-image-proxy

**TLDR:** Bitdeli is broken, and they aren't fixing it.