### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*.js]
+indent_style = tab
+indent_size = 8
+
+[*.json.tmpl]
+indent_style = spaces
+indent_size = 2
+


### PR DESCRIPTION
A simple change, just adds a .editorconfig ([you can find the spec here][1]).

Useful for keeping formatting style consistent across contributors.

[1]: https://editorconfig.org/