### PR TITLE
Add option to create a composer.json

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -299,6 +299,14 @@ Generator.prototype.doNotFearCommitment = function() {
 	}.bind(this));
 };
 
+// Create a composer.json
+Generator.prototype.createComposerJson = function() {
+	if (this.config.get('addComposer')) {
+		this.logger.log("Adding composer.json");
+		this.fs.copyTpl(this.templatePath('composer.json.tmpl'), this.destinationPath('composer.json'), { conf: this.conf });
+	}
+}
+
 // Set some permissions
 /* @TODO Thinking that maybe permissions should be left up to the user 
    BUT, it seems that the theme stuff needs some permissions set to work....

--- a/app/prompts.js
+++ b/app/prompts.js
@@ -139,6 +139,11 @@ module.exports = function(advanced, defaults) {
 			type: 'confirm',
 			default: (typeof defaults.installTheme !== 'undefined') ? defaults.installTheme : true
 		}, {
+			message: 'Add composer.json?',
+			name: 'addComposer',
+			type: 'confirm',
+			default: (typeof defaults.addComposer !== 'undefined') ? defaults.addComposer : false
+		}, {
 			message: 'Destination directory',
 			name: 'themeDir',
 			default: defaults.themeDir || 'yeopress',


### PR DESCRIPTION
While there is a generator ```wordpress:plugins``` for installing WordPress plugins, some users (me included) might prefer to manage their WordPress plugins through composer. 

This PR adds a prompt that
asks if a user wants to create a composer.json or not. If they do, then one is created based of a template.

The template used can be found in __app/template/composer.json.tmpl__.